### PR TITLE
Line item handling fee

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SpreeHandlingFees
 
-Handling fee per product variant.
+Handling fee per product variant. While [`spree-contrib/spree_handling_fees`](https://github.com/spree-contrib/spree_handling_fees) adds handling fees per shipment, this will add a handling fee per item that is being shipped.
 
 ## Installation
 
@@ -24,6 +24,20 @@ After installing, run the generator:
 
 ```
 bundle exec rails g spree_handling_fees:install
+```
+
+## Updating
+
+Copy new migrations
+
+```
+rake spree_handling_fees:install:migrations
+```
+
+Run migrations
+
+```
+rake db:migrate
 ```
 
 #### Rake
@@ -57,7 +71,6 @@ bundle exec rake spec
 
 ## TODO
 
-- Insert handling fee into `spree_line_items` for the order
 - Display handling fee in checkout with item
 - Do not charge handling fee if product is not being shipped
 - Allow optional refunding of handling fee during refund/return

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,0 +1,9 @@
+Spree::LineItem.class_eval do
+  before_create :add_handling_fee
+
+  private
+
+  def add_handling_fee
+    self.handling_fee = variant.handling_fee
+  end
+end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Variant.class_eval do
-  after_initialize :assign_default_handling_fee
+  after_initialize :assign_default_handling_fee, if: "new_record?"
 
   validates :handling_fee, presence: true,
                            numericality: { greater_than_or_equal_to: 0 }
@@ -7,6 +7,6 @@ Spree::Variant.class_eval do
   protected
 
   def assign_default_handling_fee
-    self.handling_fee = Spree::Config.handling_fee if new_record?
+    self.handling_fee = Spree::Config.handling_fee
   end
 end

--- a/config/initializers/spree_handling_fees.rb
+++ b/config/initializers/spree_handling_fees.rb
@@ -1,2 +1,2 @@
-# Add `handling_fee` as a permitted attribute for product variants
+# Add `handling_fee` as a permitted attribute for `spree_variants`
 Spree::PermittedAttributes.variant_attributes.push :handling_fee

--- a/db/migrate/20160422103002_add_handling_fee_to_spree_line_items.rb
+++ b/db/migrate/20160422103002_add_handling_fee_to_spree_line_items.rb
@@ -1,0 +1,5 @@
+class AddHandlingFeeToSpreeLineItems < ActiveRecord::Migration
+  def change
+    add_column :spree_line_items, :handling_fee, :decimal, precision: 8, scale: 2, default: 0.0
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe Spree::LineItem, type: :model do
+
+  context "with default handling fee" do
+    it "creates line_item with default (0.0) handling fee" do
+      variant = create(:variant)
+      item = create(:line_item, variant: variant)
+
+      expect(item.handling_fee).to eq 0.0
+    end
+  end
+
+  context "with custom handling fee" do
+    it "creates line_item with custom handling fee" do
+      variant = create(:variant, handling_fee: 2.15)
+      item = create(:line_item, variant: variant)
+
+      expect(item.handling_fee).to eq 2.15
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Add `handling_fee` to the line item when an item is added to the cart. This handing fee will be summed with all of the other handling fees in the order total during checkout.

# What's New

- Added `handling_fee` column to `spree_line_items` table
- Added `Updating` section to the README (not necessary for the PR but whatever man)