### PR TITLE
Order handling fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,14 @@ bundle exec rake spec
 
 ## TODO
 
-- Display handling fee in checkout with item
+- Display handling fee in admin
+- Ensure mailers report handling fees and updated total
 - Do not charge handling fee if product is not being shipped
 - Allow optional refunding of handling fee during refund/return
   - Allow partial refunding of handling fee
+- Ensure API returns handling fees and updated total
+- Ensure reports return handling fees and updated total
+- International handling fee
 
 ## Contributing
 

--- a/app/assets/stylesheets/spree/frontend/handling_fees/order_summary.scss
+++ b/app/assets/stylesheets/spree/frontend/handling_fees/order_summary.scss
@@ -1,0 +1,12 @@
+#checkout-summary {
+  table {
+    tr[data-hook="handling_fee_total"] {
+      td:last-child {
+        strong {
+          font-weight: bold;
+          color: #00ADEE;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/spree/frontend/spree_handling_fees.css
+++ b/app/assets/stylesheets/spree/frontend/spree_handling_fees.css
@@ -3,3 +3,7 @@ Placeholder manifest file.
 The installer will append this file to the app vendored assets here:
 'vendor/assets/stylesheets/spree/frontend/all.css'
 */
+
+/*
+ *= require_directory ./handling_fees
+ */

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,0 +1,5 @@
+Spree::Order.class_eval do
+  def display_handling_fee_total
+    Spree::Money.new(handling_fee_total, currency: currency)
+  end
+end

--- a/app/models/spree/order_updater_decorator.rb
+++ b/app/models/spree/order_updater_decorator.rb
@@ -1,0 +1,32 @@
+Spree::OrderUpdater.class_eval do
+  module OrderUpdaterHandlingFee
+    def update_order_total
+      super
+
+      order.total += order.handling_fee_total
+    end
+
+    def update_totals
+      super
+
+      update_handling_fee_total
+    end
+
+    def persist_totals
+      super
+
+      order.update_columns(
+        handling_fee_total: order.handling_fee_total,
+        updated_at: Time.current
+      )
+    end
+
+    def update_handling_fee_total
+      order.handling_fee_total = line_items.sum("handling_fee * quantity")
+
+      update_order_total
+    end
+  end
+
+  prepend OrderUpdaterHandlingFee
+end

--- a/app/overrides/spree/checkout/_summary/add_handling_fee_sum_to_summary.html.erb.deface
+++ b/app/overrides/spree/checkout/_summary/add_handling_fee_sum_to_summary.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- insert_before '[data-hook="order_details_tax_adjustments"]' -->
+
+<tbody>
+  <tr data-hook="handling_fee_total">
+    <td><strong><%= Spree.t("handling_fees.handling_fee") %>:</strong></td>
+    <td><strong><%= order.display_handling_fee_total.to_html %></strong></td>
+  </tr>
+</tbody>

--- a/app/overrides/spree/orders/_form/add_handling_fee_line_item.html.erb.deface
+++ b/app/overrides/spree/orders/_form/add_handling_fee_line_item.html.erb.deface
@@ -1,0 +1,7 @@
+<!-- insert_before 'tr.cart-total' -->
+
+<tr class="cart-handling-fee">
+  <td colspan="4" align='right'><h5><%= Spree.t("handling_fees.handling_fee") %></h5></th>
+  <td colspan><h5><%= order_form.object.display_handling_fee_total %></h5></td>
+  <td></td>
+</tr>

--- a/app/overrides/spree/shared/_order_details/add_handling_fee_adjustment.html.erb.deface
+++ b/app/overrides/spree/shared/_order_details/add_handling_fee_adjustment.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- insert_before '[data-hook="order_details_adjustments"]' -->
+
+<tfoot id="order-charges" data-hook="order_details_adjustments">
+  <tr class="total">
+    <td colspan="4"><strong><%= Spree.t("handling_fees.handling_fee") %></strong></td>
+    <td class="total"><span><%= order.display_handling_fee_total.to_html %></span></td>
+  </tr>
+</tfoot>

--- a/db/migrate/20160422145605_add_handling_fee_total_to_spree_orders.rb
+++ b/db/migrate/20160422145605_add_handling_fee_total_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddHandlingFeeTotalToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :handling_fee_total, :decimal, precision: 8, scale: 2, default: 0.0
+  end
+end

--- a/spec/features/handling_fee_in_checkout_spec.rb
+++ b/spec/features/handling_fee_in_checkout_spec.rb
@@ -1,0 +1,79 @@
+require "spec_helper"
+
+RSpec.feature "Throughout checkout process", type: :feature do
+  let!(:country) { create(:country, name: "United States of America") }
+  let!(:state) { create(:state, name: "Alabama", abbr: "AL", country: country) }
+
+  let!(:shipping_method) { create(:shipping_method) }
+  let!(:stock_location) { create(:stock_location) }
+  let!(:payment_method) { create(:check_payment_method) }
+  let!(:zone) { create(:zone) }
+
+  let(:handling_fee_amount) { 1.23 }
+  let(:purchase_quantity) { 2 }
+  let!(:variant) { create(:variant, handling_fee: handling_fee_amount) }
+
+  before { visit spree.product_path(variant.product) }
+
+  it "displays handling fee is available", js: true do
+    # Product detail page
+    fill_in "quantity", with: purchase_quantity
+
+    click_button Spree.t(:add_to_cart)
+
+    # Cart
+    expect(page).to have_content Spree.t("handling_fees.handling_fee")
+    expect(page).to have_content calculated_handling_fee
+
+    click_button Spree.t(:checkout)
+
+    # Login (as a guest)
+    fill_in "order_email", with: "me@example.com"
+
+    click_button Spree.t(:continue)
+
+    # Checkout - Address
+    fill_in_address
+
+    expect(page).to have_content Spree.t("handling_fees.handling_fee")
+    expect(page).to have_content calculated_handling_fee
+
+    click_button Spree.t(:save_and_continue)
+
+    # Checkout - Delivery
+    expect(page).to have_content Spree.t("handling_fees.handling_fee")
+    expect(page).to have_content calculated_handling_fee
+
+    click_button Spree.t(:save_and_continue)
+
+    # Checkout - Payment
+    expect(page).to have_content Spree.t("handling_fees.handling_fee")
+    expect(page).to have_content calculated_handling_fee
+
+    click_button Spree.t(:save_and_continue)
+
+    # Complete / Receipt
+    expect(current_path).to include spree.order_path(Spree::Order.last)
+    expect(page).to have_content Spree.t(:order_processed_successfully)
+    expect(page).to have_content Spree.t("handling_fees.handling_fee")
+    expect(page).to have_content calculated_handling_fee
+  end
+
+  def calculated_handling_fee
+    fee = handling_fee_amount * purchase_quantity
+
+    "$#{fee}"
+  end
+
+  def fill_in_address
+    address = "order_bill_address_attributes"
+    fill_in "#{address}_firstname", with: "Ryan"
+    fill_in "#{address}_lastname", with: "Bigg"
+    fill_in "#{address}_address1", with: "143 Swan Street"
+    fill_in "#{address}_city", with: "Richmond"
+    select "United States of America", from: "#{address}_country_id"
+    select "Alabama", from: "#{address}_state_id"
+    fill_in "#{address}_zipcode", with: "12345"
+    fill_in "#{address}_phone", with: "(555) 555-5555"
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 RSpec.describe Spree::LineItem, type: :model do
-
   context "with default handling fee" do
     it "creates line_item with default (0.0) handling fee" do
       variant = create(:variant)


### PR DESCRIPTION
# Summary

Display handling fee throughout checkout process.

# What's New

- Show handling fee throughout the checkout process
- Add `handling_fee_total` column to `spree_orders` table

/cc @comeara 