### PR TITLE
Shipping calculation

### DIFF
--- a/app/models/spree/calculator/handling_fee_calculator.rb
+++ b/app/models/spree/calculator/handling_fee_calculator.rb
@@ -4,19 +4,18 @@ module Spree
       Spree.t("handling_fees.calculator_description")
     end
 
+    # This is only here for Spree < 2.2. Spree 2.2+ calculates on shipment and
+    # line items rather than order
     def compute_order(_order)
       raise "Spree::Calculator::HandlingFeeCalculator is designed to " \
             "calculate taxes at the line-item level."
     end
 
-    def compute_shipment(_shipment)
-      raise "Spree::Calculator::HandlingFeeCalculator is designed to " \
-            "calculate taxes at the line-item level."
-    end
-
-    def compute_line_item(item)
+    def compute_shipment_or_line_item(item)
       round_to_two_places calculate_handling_fee_for(item)
     end
+    alias_method :compute_shipment, :compute_shipment_or_line_item
+    alias_method :compute_line_item, :compute_shipment_or_line_item
 
     private
 

--- a/app/overrides/spree/orders/_adjustment_row/remove_tax_from_adjustment.html.erb.deface
+++ b/app/overrides/spree/orders/_adjustment_row/remove_tax_from_adjustment.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- replace_contents "tr.adjustment td:first-child" -->
+
+<%# If any of the adjustment calculator types are 'Spree::Calculator::HandlingFeeCalculator' then remove the `Tax:` prefix %>
+<% if adjustments.any? { |a| a.source.calculator.type == "Spree::Calculator::HandlingFeeCalculator" } %>
+  <h5><%= label %></h5>
+<% else %>
+  <h5><%= type %>: <%= label %></h5>
+<% end %>

--- a/app/overrides/spree/shared/_order_details/remove_tax_from_adjustments.html.erb.deface
+++ b/app/overrides/spree/shared/_order_details/remove_tax_from_adjustments.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- replace_contents "tfoot#tax-adjustments tr.total td:first-child" -->
+
+<%# If any of the adjustment calculator types are 'Spree::Calculator::HandlingFeeCalculator' then remove the `Tax:` prefix %>
+<% if adjustments.any? { |a| a.source.calculator.type == "Spree::Calculator::HandlingFeeCalculator" } %>
+  <strong><%= label %></strong>
+<% else %>
+  <%= Spree.t(:tax) %>: <strong><%= label %></strong>
+<% end %>

--- a/spec/features/handling_fee_in_checkout_spec.rb
+++ b/spec/features/handling_fee_in_checkout_spec.rb
@@ -67,6 +67,7 @@ RSpec.feature "Throughout checkout process", type: :feature, js: true do
     # Complete / Receipt
     expect(current_path).to include spree.order_path(Spree::Order.last)
     expect(page).to have_content Spree.t(:order_processed_successfully)
+    expect(page).not_to have_content("#{Spree.t(:tax)}: #{handling_fee_label}")
     expect(page).to have_content handling_fee_label
     expect(page).to have_content calculated_handling_fee
   end

--- a/spec/models/spree/calculator/handling_fee_calculator_spec.rb
+++ b/spec/models/spree/calculator/handling_fee_calculator_spec.rb
@@ -48,17 +48,14 @@ describe Spree::Calculator::HandlingFeeCalculator, type: :model do
   end
 
   context "#compute_shipment" do
-    it "raises an error" do
-      expect { subject.compute_shipment(order) }.to raise_error(
-        "Spree::Calculator::HandlingFeeCalculator is designed to " \
-        "calculate taxes at the line-item level."
-      )
+    it "should be equal to the item's handling fee * quantity" do
+      expect(calculator.compute_shipment(line_item)).to eq 6.28
     end
   end
 
   context "#compute_line_item" do
     it "should be equal to the item's handling fee * quantity" do
-      expect(calculator.compute(line_item)).to eq 6.28
+      expect(calculator.compute_line_item(line_item)).to eq 6.28
     end
   end
 


### PR DESCRIPTION
# Summary

This is a bugfix. An error was being thrown during checkout. I was raising an error during shipping calculation because it needed to calculate for the line item. I didn't realize the calculation would also need to run when calculating shipping. Both values end up being the same. I guess it just needs to do the extra work to calculate the same value it already has.

# What's new

- Remove the `Tax:` prefix next to the handling fee label on cart and confirm/receipt pages
- Tests to show the removal

# What's changed

- Corrected calculation for shipping to calculate total instead of raise an error
- Tests to reflect this change

/cc @comeara @mattsergent 